### PR TITLE
File reading utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+ncc-test-*

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+pub mod utils;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod unicode;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,1 @@
-pub mod unicode;
+pub mod reader;

--- a/src/utils/reader.rs
+++ b/src/utils/reader.rs
@@ -345,18 +345,10 @@ mod tests {
         }
     }
 
-    /// Utility for making a temporary file.
-    fn temp_file(p: &'static str, contents: &[u8]) -> &'static Path {
-        let path = Path::new(p);
-        let mut f = File::create(&path).unwrap();
-        f.write_all(contents).unwrap();
-        path
-    }
-
     #[test]
     fn single_letter() {
-        let path = temp_file("./ncc-test-single-letter", b"a");
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-single-letter", b"a");
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
             (CharAtom::EOF, FileLoc::new((1, 2), 1)),
@@ -366,8 +358,8 @@ mod tests {
 
     #[test]
     fn multi_letter() {
-        let path = temp_file("./ncc-test-multi-letter", b"ab");
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-multi-letter", b"ab");
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
             (CharAtom::Valid('b'), FileLoc::new((1, 2), 1)),
@@ -378,8 +370,8 @@ mod tests {
 
     #[test]
     fn multi_letter_and_newline() {
-        let path = temp_file("./ncc-test-multi-letter-and-newline", b"abc\na");
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-multi-letter-and-newline", b"abc\na");
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
             (CharAtom::Valid('b'), FileLoc::new((1, 2), 1)),
@@ -393,8 +385,8 @@ mod tests {
 
     #[test]
     fn carriage_return() {
-        let path = temp_file("./ncc-test-carriage_return", b"a\rc");
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-carriage_return", b"a\rc");
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
             (CharAtom::Newline(Newline::CR), FileLoc::new((1, 2), 1)),
@@ -406,8 +398,8 @@ mod tests {
 
     #[test]
     fn windows_return() {
-        let path = temp_file("./ncc-test-windows-return", b"a\r\nc");
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-windows-return", b"a\r\nc");
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
             (CharAtom::Newline(Newline::CRLF), FileLoc::new((1, 2), 1)),
@@ -419,24 +411,24 @@ mod tests {
 
     #[test]
     fn broken_codepoints() {
-        let path = temp_file("./ncc-test-broken-codepoint", &[0xF0]);
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-broken-codepoint", &[0xF0]);
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Invalid(0xF0_00_00_00), FileLoc::new((1, 1), 0)),
             (CharAtom::EOF, FileLoc::new((1, 2), 1)),
         ];
         assert_eq!(reader.collect(), expected);
 
-        let path = temp_file("./ncc-test-broken-codepoint-2b", &[0xF0, 0xAA]);
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-broken-codepoint-2b", &[0xF0, 0xAA]);
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Invalid(0xF0_AA_00_00), FileLoc::new((1, 1), 0)),
             (CharAtom::EOF, FileLoc::new((1, 2), 2)),
         ];
         assert_eq!(reader.collect(), expected);
 
-        let path = temp_file("./ncc-test-broken-codepoint-3b", &[0xF0, 0xAA, 0xAA]);
-        let mut reader = AtomReader::new(&path).unwrap();
+        let tmp = TempFile::new("./ncc-test-broken-codepoint-3b", &[0xF0, 0xAA, 0xAA]);
+        let mut reader = AtomReader::new(tmp.p.as_path()).unwrap();
         let expected = vec![
             (CharAtom::Invalid(0xF0_AA_AA_00), FileLoc::new((1, 1), 0)),
             (CharAtom::EOF, FileLoc::new((1, 2), 3)),

--- a/src/utils/reader.rs
+++ b/src/utils/reader.rs
@@ -270,8 +270,7 @@ impl AtomReader {
 impl StreamReader for AtomReader {
     type Item = (CharAtom, FileLoc);
 
-    /// Fetches a tuple of the next `CharAtom` from the file and its location,
-    /// which is itself a tuple of (row, column).
+    /// Fetches a tuple of the next `CharAtom` from the file and its location.
     fn consume(&mut self) -> Self::Item {
         self.pos.offset = self.reader.total_offset;
         let raw_codepoint = self.reader.consume();

--- a/src/utils/reader.rs
+++ b/src/utils/reader.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
-use std::path::Path;
 use std::io::Read;
+use std::path::Path;
 
 /// Returns the initial codepoint accumulator for the first byte.
 /// The first byte is special, only want bottom 5 bits for width 2, 4 bits
@@ -36,10 +36,7 @@ pub struct FileLoc {
 
 impl FileLoc {
     pub fn new(index: (usize, usize), offset: usize) -> Self {
-	FileLoc {
-	    index,
-	    offset
-	}
+        FileLoc { index, offset }
     }
 }
 
@@ -82,7 +79,7 @@ struct CodepointReader {
     total_offset: usize,
     partial: Option<usize>,
     secondary: bool,
-    last: bool
+    last: bool,
 }
 
 impl CodepointReader {
@@ -95,28 +92,28 @@ impl CodepointReader {
     /// Either a `CodepointReader` or a `std::io::Error`
     /// if opening file and initial reads fail.
     fn new(path: &Path) -> Result<Self, std::io::Error> {
-	let mut reader = CodepointReader {
-	    f: File::open(path)?,
-	    buf1: [0; 4096],
-	    buf2: [0; 4096],
-	    index: 0,
-	    total_offset: 0,
-	    partial: None,
-	    secondary: false,
-	    last: false,
-	};
-	let sz = reader.f.read(&mut reader.buf1)?;
-	if sz != 4096 {
-	    reader.last = true;
-	    reader.partial = Some(sz);
-	    return Ok(reader);
-	}
-	let sz2 = reader.f.read(&mut reader.buf2)?;
-	if sz2 != 4096 {
-	    reader.partial = Some(sz2);
-	    return Ok(reader);
-	}
-	Ok(reader)
+        let mut reader = CodepointReader {
+            f: File::open(path)?,
+            buf1: [0; 4096],
+            buf2: [0; 4096],
+            index: 0,
+            total_offset: 0,
+            partial: None,
+            secondary: false,
+            last: false,
+        };
+        let sz = reader.f.read(&mut reader.buf1)?;
+        if sz != 4096 {
+            reader.last = true;
+            reader.partial = Some(sz);
+            return Ok(reader);
+        }
+        let sz2 = reader.f.read(&mut reader.buf2)?;
+        if sz2 != 4096 {
+            reader.partial = Some(sz2);
+            return Ok(reader);
+        }
+        Ok(reader)
     }
 
     /// Gets the next byte from the file.
@@ -124,48 +121,52 @@ impl CodepointReader {
     /// # Returns
     /// `u8` if there is another byte, `None` if there isn't.
     fn get_byte(&mut self) -> Option<u8> {
-	if self.index == 4096 {
-	    if let Some(_) = self.partial {
-		self.last = true;
-	    } else {
-		let sz = match self.secondary {
-		    false => self.f.read(&mut self.buf1).unwrap(),
-		    true => self.f.read(&mut self.buf2).unwrap(),
-		};
-		if sz != 4096 { self.partial = Some(sz) }
-	    }
-	    self.secondary = !self.secondary;
-	    self.index = 0;
-	}
+        if self.index == 4096 {
+            if let Some(_) = self.partial {
+                self.last = true;
+            } else {
+                let sz = match self.secondary {
+                    false => self.f.read(&mut self.buf1).unwrap(),
+                    true => self.f.read(&mut self.buf2).unwrap(),
+                };
+                if sz != 4096 {
+                    self.partial = Some(sz)
+                }
+            }
+            self.secondary = !self.secondary;
+            self.index = 0;
+        }
 
-	let out = if self.last && self.index >= self.partial.unwrap_or(4096) {
-	    None
-	} else if self.secondary {
-	    Some(self.buf2[self.index])
-	} else {
-	    Some(self.buf1[self.index])
-	};
-	self.index += 1;
-	if let Some(_) = out { self.total_offset += 1; }
-	out
+        let out = if self.last && self.index >= self.partial.unwrap_or(4096) {
+            None
+        } else if self.secondary {
+            Some(self.buf2[self.index])
+        } else {
+            Some(self.buf1[self.index])
+        };
+        self.index += 1;
+        if let Some(_) = out {
+            self.total_offset += 1;
+        }
+        out
     }
 
     // TODO expand capabilities to support rest of multi code point sequences
     fn lookahead(&self) -> Option<u8> {
-	if self.index == 4096 {
-	    match self.secondary {
-		true => Some(self.buf1[0]),
-		false => Some(self.buf2[0]),
-	    }
-	} else {
-	    if self.index > self.partial.unwrap_or(4096) && self.last {
-		return None;
-	    }
-	    match self.secondary {
-		false => Some(self.buf1[self.index]),
-		true => Some(self.buf2[self.index]),
-	    }
-	}
+        if self.index == 4096 {
+            match self.secondary {
+                true => Some(self.buf1[0]),
+                false => Some(self.buf2[0]),
+            }
+        } else {
+            if self.index > self.partial.unwrap_or(4096) && self.last {
+                return None;
+            }
+            match self.secondary {
+                false => Some(self.buf1[self.index]),
+                true => Some(self.buf2[self.index]),
+            }
+        }
     }
 }
 
@@ -175,55 +176,53 @@ impl StreamReader for CodepointReader {
     /// Parses the next unicode codepoint into a `Codepoint`.
     /// If a codepoint is invalid/incomplete, will set the remaining bytes to 0.
     fn consume(&mut self) -> Self::Item {
-	let x = match self.get_byte() {
-	    None => return None,
-	    Some(c) => c,
-	};
-	if x < 128 { return Some(Codepoint::Valid(x as u32)); }
+        let x = match self.get_byte() {
+            None => return None,
+            Some(c) => c,
+        };
+        if x < 128 {
+            return Some(Codepoint::Valid(x as u32));
+        }
 
-	let init = utf8_first_byte(x, 2);
-	let y = match self.get_byte() {
-	    None => return Some(Codepoint::Invalid((x as u32) << 24)),
-	    Some(c) => c
-	};
-	let mut ch = utf8_acc_cont_byte(init, y);
-	if x >= 0xE0 {
-	    let z = match self.get_byte() {
-		None => {
-		    return Some(Codepoint::Invalid(
-			((x as u32) << 24) | ((y as u32) << 16)
-		    ))
-		},
-		Some(c) => c,
-	    };
-	    let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
-	    ch = init << 12 | y_z;
+        let init = utf8_first_byte(x, 2);
+        let y = match self.get_byte() {
+            None => return Some(Codepoint::Invalid((x as u32) << 24)),
+            Some(c) => c,
+        };
+        let mut ch = utf8_acc_cont_byte(init, y);
+        if x >= 0xE0 {
+            let z = match self.get_byte() {
+                None => return Some(Codepoint::Invalid(((x as u32) << 24) | ((y as u32) << 16))),
+                Some(c) => c,
+            };
+            let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
+            ch = init << 12 | y_z;
 
-	    if x >= 0xF0 {
-		let w = match self.get_byte() {
-		    None => {
-			return Some(Codepoint::Invalid(
-			    ((x as u32) << 24) | ((y as u32) << 16) | ((z as u32) << 8)
-			))
-		    },
-		    Some(c) => c,
-		};
-		ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
-	    }
-	}
-	Some(Codepoint::Valid(ch))
+            if x >= 0xF0 {
+                let w = match self.get_byte() {
+                    None => {
+                        return Some(Codepoint::Invalid(
+                            ((x as u32) << 24) | ((y as u32) << 16) | ((z as u32) << 8),
+                        ))
+                    }
+                    Some(c) => c,
+                };
+                ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
+            }
+        }
+        Some(Codepoint::Valid(ch))
     }
 
     fn collect(&mut self) -> Vec<Self::Item> {
-	let mut v = Vec::new();
-	loop {
-	    let atom = self.consume();
-	    v.push(atom);
-	    if atom == None {
-		break;
-	    }
-	}
-	v
+        let mut v = Vec::new();
+        loop {
+            let atom = self.consume();
+            v.push(atom);
+            if atom == None {
+                break;
+            }
+        }
+        v
     }
 }
 
@@ -255,10 +254,10 @@ impl AtomReader {
     /// Either a `AtomReader` or a `std::io::Error`
     /// if opening file and initial reads fail.
     pub fn new(path: &Path) -> Result<Self, std::io::Error> {
-	Ok(AtomReader {
-	    reader: CodepointReader::new(path)?,
-	    pos: FileLoc::new((1,0), 0),
-	})
+        Ok(AtomReader {
+            reader: CodepointReader::new(path)?,
+            pos: FileLoc::new((1, 0), 0),
+        })
     }
 }
 
@@ -268,48 +267,48 @@ impl StreamReader for AtomReader {
     /// Fetches a tuple of the next `CharAtom` from the file and its location,
     /// which is itself a tuple of (row, column).
     fn consume(&mut self) -> Self::Item {
-	self.pos.offset = self.reader.total_offset;
-	let raw_codepoint = self.reader.consume();
-	self.pos.index.1 += 1;
-	let ch = match raw_codepoint {
-	    None => return (CharAtom::EOF, self.pos),
-	    Some(codepoint) => match codepoint {
-		Codepoint::Invalid(c) => return (CharAtom::Invalid(c), self.pos),
-		Codepoint::Valid(c) => c,
-	    }
-	};
-	let atom = match ch {
-	    0x0a => CharAtom::Newline(Newline::LF),
-	    0x0d => {
-		if self.reader.lookahead().unwrap_or(0x00) == 0x0a {
-		    self.reader.get_byte();
-		    CharAtom::Newline(Newline::CRLF)
-		} else {
-		    CharAtom::Newline(Newline::CR)
-		}
-	    }
-	    _ => CharAtom::Valid(std::char::from_u32(ch).unwrap()),
-	};
-	let out = (atom, self.pos);
-	match atom {
-	    CharAtom::Newline(_) => {
-		self.pos.index = (self.pos.index.0 + 1, 0);
-	    },
-	    _ => {},
-	};
-	out
+        self.pos.offset = self.reader.total_offset;
+        let raw_codepoint = self.reader.consume();
+        self.pos.index.1 += 1;
+        let ch = match raw_codepoint {
+            None => return (CharAtom::EOF, self.pos),
+            Some(codepoint) => match codepoint {
+                Codepoint::Invalid(c) => return (CharAtom::Invalid(c), self.pos),
+                Codepoint::Valid(c) => c,
+            },
+        };
+        let atom = match ch {
+            0x0a => CharAtom::Newline(Newline::LF),
+            0x0d => {
+                if self.reader.lookahead().unwrap_or(0x00) == 0x0a {
+                    self.reader.get_byte();
+                    CharAtom::Newline(Newline::CRLF)
+                } else {
+                    CharAtom::Newline(Newline::CR)
+                }
+            }
+            _ => CharAtom::Valid(std::char::from_u32(ch).unwrap()),
+        };
+        let out = (atom, self.pos);
+        match atom {
+            CharAtom::Newline(_) => {
+                self.pos.index = (self.pos.index.0 + 1, 0);
+            }
+            _ => {}
+        };
+        out
     }
 
     fn collect(&mut self) -> Vec<Self::Item> {
-	let mut v = Vec::new();
-	loop {
-	    let atom = self.consume();
-	    v.push(atom);
-	    if atom.0 == CharAtom::EOF {
-		break;
-	    }
-	}
-	v
+        let mut v = Vec::new();
+        loop {
+            let atom = self.consume();
+            v.push(atom);
+            if atom.0 == CharAtom::EOF {
+                break;
+            }
+        }
+        v
     }
 }
 
@@ -320,100 +319,100 @@ mod tests {
 
     /// Utility for making a temporary file.
     fn temp_file(p: &'static str, contents: &[u8]) -> &'static Path {
-	let path = Path::new(p);
-	let mut f = File::create(&path).unwrap();
-	f.write_all(contents).unwrap();
-	path
+        let path = Path::new(p);
+        let mut f = File::create(&path).unwrap();
+        f.write_all(contents).unwrap();
+        path
     }
 
     #[test]
     fn single_letter() {
-	let path = temp_file("./ncc-test-single-letter", b"a");
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Valid('a'), FileLoc::new((1,1), 0)),
-	    (CharAtom::EOF, FileLoc::new((1,2), 1)),
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-single-letter", b"a");
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
+            (CharAtom::EOF, FileLoc::new((1, 2), 1)),
+        ];
+        assert_eq!(reader.collect(), expected);
     }
 
     #[test]
     fn multi_letter() {
-	let path = temp_file("./ncc-test-multi-letter", b"ab");
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Valid('a'), FileLoc::new((1,1), 0)),
-	    (CharAtom::Valid('b'), FileLoc::new((1,2), 1)),
-	    (CharAtom::EOF, FileLoc::new((1,3), 2))
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-multi-letter", b"ab");
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
+            (CharAtom::Valid('b'), FileLoc::new((1, 2), 1)),
+            (CharAtom::EOF, FileLoc::new((1, 3), 2)),
+        ];
+        assert_eq!(reader.collect(), expected);
     }
 
     #[test]
     fn multi_letter_and_newline() {
-	let path = temp_file("./ncc-test-multi-letter-and-newline", b"abc\na");
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Valid('a'), FileLoc::new((1,1), 0)),
-	    (CharAtom::Valid('b'), FileLoc::new((1,2), 1)),
-	    (CharAtom::Valid('c'), FileLoc::new((1,3), 2)),
-	    (CharAtom::Newline(Newline::LF), FileLoc::new((1,4), 3)),
-	    (CharAtom::Valid('a'), FileLoc::new((2,1), 4)),
-	    (CharAtom::EOF, FileLoc::new((2,2), 5)),
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-multi-letter-and-newline", b"abc\na");
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
+            (CharAtom::Valid('b'), FileLoc::new((1, 2), 1)),
+            (CharAtom::Valid('c'), FileLoc::new((1, 3), 2)),
+            (CharAtom::Newline(Newline::LF), FileLoc::new((1, 4), 3)),
+            (CharAtom::Valid('a'), FileLoc::new((2, 1), 4)),
+            (CharAtom::EOF, FileLoc::new((2, 2), 5)),
+        ];
+        assert_eq!(reader.collect(), expected);
     }
 
     #[test]
     fn carriage_return() {
-	let path = temp_file("./ncc-test-carriage_return", b"a\rc");
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Valid('a'), FileLoc::new((1,1), 0)),
-	    (CharAtom::Newline(Newline::CR), FileLoc::new((1,2), 1)),
-	    (CharAtom::Valid('c'), FileLoc::new((2,1), 2)),
-	    (CharAtom::EOF, FileLoc::new((2,2), 3))
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-carriage_return", b"a\rc");
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
+            (CharAtom::Newline(Newline::CR), FileLoc::new((1, 2), 1)),
+            (CharAtom::Valid('c'), FileLoc::new((2, 1), 2)),
+            (CharAtom::EOF, FileLoc::new((2, 2), 3)),
+        ];
+        assert_eq!(reader.collect(), expected);
     }
 
     #[test]
     fn windows_return() {
-	let path = temp_file("./ncc-test-windows-return", b"a\r\nc");
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Valid('a'), FileLoc::new((1,1), 0)),
-	    (CharAtom::Newline(Newline::CRLF), FileLoc::new((1,2), 1)),
-	    (CharAtom::Valid('c'), FileLoc::new((2,1), 3)),
-	    (CharAtom::EOF, FileLoc::new((2,2), 4))
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-windows-return", b"a\r\nc");
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Valid('a'), FileLoc::new((1, 1), 0)),
+            (CharAtom::Newline(Newline::CRLF), FileLoc::new((1, 2), 1)),
+            (CharAtom::Valid('c'), FileLoc::new((2, 1), 3)),
+            (CharAtom::EOF, FileLoc::new((2, 2), 4)),
+        ];
+        assert_eq!(reader.collect(), expected);
     }
 
     #[test]
     fn broken_codepoints() {
-	let path = temp_file("./ncc-test-broken-codepoint", &[0xF0]);
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Invalid(0xF0_00_00_00), FileLoc::new((1,1), 0)),
-	    (CharAtom::EOF, FileLoc::new((1,2), 1))
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-broken-codepoint", &[0xF0]);
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Invalid(0xF0_00_00_00), FileLoc::new((1, 1), 0)),
+            (CharAtom::EOF, FileLoc::new((1, 2), 1)),
+        ];
+        assert_eq!(reader.collect(), expected);
 
-	let path = temp_file("./ncc-test-broken-codepoint-2b", &[0xF0, 0xAA]);
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Invalid(0xF0_AA_00_00), FileLoc::new((1,1), 0)),
-	    (CharAtom::EOF, FileLoc::new((1,2), 2))
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-broken-codepoint-2b", &[0xF0, 0xAA]);
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Invalid(0xF0_AA_00_00), FileLoc::new((1, 1), 0)),
+            (CharAtom::EOF, FileLoc::new((1, 2), 2)),
+        ];
+        assert_eq!(reader.collect(), expected);
 
-	let path = temp_file("./ncc-test-broken-codepoint-3b", &[0xF0, 0xAA, 0xAA]);
-	let mut reader = AtomReader::new(&path).unwrap();
-	let expected = vec![
-	    (CharAtom::Invalid(0xF0_AA_AA_00), FileLoc::new((1,1), 0)),
-	    (CharAtom::EOF, FileLoc::new((1,2), 3))
-	];
-	assert_eq!(reader.collect(), expected);
+        let path = temp_file("./ncc-test-broken-codepoint-3b", &[0xF0, 0xAA, 0xAA]);
+        let mut reader = AtomReader::new(&path).unwrap();
+        let expected = vec![
+            (CharAtom::Invalid(0xF0_AA_AA_00), FileLoc::new((1, 1), 0)),
+            (CharAtom::EOF, FileLoc::new((1, 2), 3)),
+        ];
+        assert_eq!(reader.collect(), expected);
     }
 }

--- a/src/utils/reader.rs
+++ b/src/utils/reader.rs
@@ -20,6 +20,11 @@ const fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
 }
 
 ///
+/// Represents position in file as (row, column).
+///
+type FileLoc = (usize, usize);
+
+///
 /// An individual Unicode codepoint.
 /// Can potentially take the form of a right-padded u32 if codepoint is invalid.
 ///
@@ -80,27 +85,27 @@ impl CodepointReader {
     /// if opening file and initial reads fail.
     ///
     fn new(path: &Path) -> Result<Self, std::io::Error> {
-        let mut reader = CodepointReader {
-            f: File::open(path)?,
-            buf1: [0; 4096],
-            buf2: [0; 4096],
-            index: 0,
-            partial: None,
-            secondary: false,
-            last: false,
-        };
-        let sz = reader.f.read(&mut reader.buf1)?;
-        if sz != 4096 {
-            reader.last = true;
-            reader.partial = Some(sz);
-            return Ok(reader);
-        }
-        let sz2 = reader.f.read(&mut reader.buf2)?;
-        if sz2 != 4096 {
-            reader.partial = Some(sz2);
-            return Ok(reader);
-        }
-        Ok(reader)
+	let mut reader = CodepointReader {
+	    f: File::open(path)?,
+	    buf1: [0; 4096],
+	    buf2: [0; 4096],
+	    index: 0,
+	    partial: None,
+	    secondary: false,
+	    last: false,
+	};
+	let sz = reader.f.read(&mut reader.buf1)?;
+	if sz != 4096 {
+	    reader.last = true;
+	    reader.partial = Some(sz);
+	    return Ok(reader);
+	}
+	let sz2 = reader.f.read(&mut reader.buf2)?;
+	if sz2 != 4096 {
+	    reader.partial = Some(sz2);
+	    return Ok(reader);
+	}
+	Ok(reader)
     }
 
     ///
@@ -108,49 +113,49 @@ impl CodepointReader {
     ///
     /// # Returns
     /// `u8` if there is another byte, `None` if there isn't.
-    /// 
+    ///
     fn get_byte(&mut self) -> Option<u8> {
-        if self.index == 4096 {
-            if let Some(_) = self.partial {
-                self.last = true;
-            } else {
-                let sz = match self.secondary {
-                    false => self.f.read(&mut self.buf1).unwrap(),
-                    true => self.f.read(&mut self.buf2).unwrap(),
-                };
-                if sz != 4096 { self.partial = Some(sz) }
-            }
-            self.secondary = !self.secondary;
-            self.index = 0;
-        }
+	if self.index == 4096 {
+	    if let Some(_) = self.partial {
+		self.last = true;
+	    } else {
+		let sz = match self.secondary {
+		    false => self.f.read(&mut self.buf1).unwrap(),
+		    true => self.f.read(&mut self.buf2).unwrap(),
+		};
+		if sz != 4096 { self.partial = Some(sz) }
+	    }
+	    self.secondary = !self.secondary;
+	    self.index = 0;
+	}
 
-        let out = if self.last && self.index >= self.partial.unwrap_or(4096) {
-            None
-        } else if self.secondary {
-            Some(self.buf2[self.index])
-        } else {
-            Some(self.buf1[self.index])
-        };
-        self.index += 1;
-        out
+	let out = if self.last && self.index >= self.partial.unwrap_or(4096) {
+	    None
+	} else if self.secondary {
+	    Some(self.buf2[self.index])
+	} else {
+	    Some(self.buf1[self.index])
+	};
+	self.index += 1;
+	out
     }
 
     // TODO expand capabilities to support rest of multi code point sequences
     fn lookahead(&self) -> Option<u8> {
-        if self.index == 4096 {
-            match self.secondary {
-                true => Some(self.buf1[0]),
-                false => Some(self.buf2[0]),
-            }
-        } else {
-            if self.index > self.partial.unwrap_or(4096) && self.last {
-                return None;
-            }
-            match self.secondary {
-                false => Some(self.buf1[self.index]),
-                true => Some(self.buf2[self.index]),
-            }
-        }
+	if self.index == 4096 {
+	    match self.secondary {
+		true => Some(self.buf1[0]),
+		false => Some(self.buf2[0]),
+	    }
+	} else {
+	    if self.index > self.partial.unwrap_or(4096) && self.last {
+		return None;
+	    }
+	    match self.secondary {
+		false => Some(self.buf1[self.index]),
+		true => Some(self.buf2[self.index]),
+	    }
+	}
     }
 }
 
@@ -159,53 +164,53 @@ impl Iterator for CodepointReader {
 
     ///
     /// Parses the next unicode codepoint into a `Codepoint`.
-    /// If a codepoint is invalid/incomplete, will set the remaining bytes to 0. 
+    /// If a codepoint is invalid/incomplete, will set the remaining bytes to 0.
     ///
     fn next(&mut self) -> Option<Self::Item> {
-        let x = match self.get_byte() {
-            None => return None,
-            Some(c) => c,
-        };
-        if x < 128 { return Some(Codepoint::Valid(x as u32)); }
+	let x = match self.get_byte() {
+	    None => return None,
+	    Some(c) => c,
+	};
+	if x < 128 { return Some(Codepoint::Valid(x as u32)); }
 
-        let init = utf8_first_byte(x, 2);
-        let y = match self.get_byte() {
-            None => return Some(Codepoint::Invalid((x as u32) << 24)),
-            Some(c) => {
-                println!("Valid second char! {}", c);
-                c
-            }
-        };
-        let mut ch = utf8_acc_cont_byte(init, y);
-        if x >= 0xE0 {
-            let z = match self.get_byte() {
-                None => {
-                    return Some(Codepoint::Invalid(
-                        ((x as u32) << 24) | ((y as u32) << 16)
-                    ))
-                },
-                Some(c) => c,
-            };
-            let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
-            ch = init << 12 | y_z;
+	let init = utf8_first_byte(x, 2);
+	let y = match self.get_byte() {
+	    None => return Some(Codepoint::Invalid((x as u32) << 24)),
+	    Some(c) => {
+		println!("Valid second char! {}", c);
+		c
+	    }
+	};
+	let mut ch = utf8_acc_cont_byte(init, y);
+	if x >= 0xE0 {
+	    let z = match self.get_byte() {
+		None => {
+		    return Some(Codepoint::Invalid(
+			((x as u32) << 24) | ((y as u32) << 16)
+		    ))
+		},
+		Some(c) => c,
+	    };
+	    let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
+	    ch = init << 12 | y_z;
 
-            if x >= 0xF0 {
-                let w = match self.get_byte() {
-                    None => {
-                        return Some(Codepoint::Invalid(
-                            ((x as u32) << 24) | ((y as u32) << 16) | ((z as u32) << 8)
-                        ))
-                    },
-                    Some(c) => c,
-                };
-                ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
-            }
-        }
-        Some(Codepoint::Valid(ch))
+	    if x >= 0xF0 {
+		let w = match self.get_byte() {
+		    None => {
+			return Some(Codepoint::Invalid(
+			    ((x as u32) << 24) | ((y as u32) << 16) | ((z as u32) << 8)
+			))
+		    },
+		    Some(c) => c,
+		};
+		ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
+	    }
+	}
+	Some(Codepoint::Valid(ch))
     }
 }
 
-/// 
+///
 /// Reader for accessing a file a `CharAtom` at a time.
 ///
 /// # Examples
@@ -213,15 +218,16 @@ impl Iterator for CodepointReader {
 /// let path = std::path::Path::new("./test.c");
 /// let r = AtomReader::new(&path).unwrap();
 /// for i in r {
-/// 	println!("{:?}", i);
-/// 	if i == CharAtom::EOF {
-/// 		break;
-/// 	}
+///	println!("{:?}", i);
+///	if i == CharAtom::EOF {
+///		break;
+///	}
 /// }
 /// ```
 ///
 pub struct AtomReader {
     reader: CodepointReader,
+    pos: FileLoc,
 }
 
 impl AtomReader {
@@ -236,39 +242,52 @@ impl AtomReader {
     /// if opening file and initial reads fail.
     ///
     pub fn new(path: &Path) -> Result<Self, std::io::Error> {
-        Ok(AtomReader {
-            reader: CodepointReader::new(path)?
-        })
+	Ok(AtomReader {
+	    reader: CodepointReader::new(path)?,
+	    pos: (1,0),
+	})
     }
 }
 
 impl Iterator for AtomReader {
-    type Item = CharAtom;
+    type Item = (CharAtom, FileLoc);
 
     ///
-    /// Fetches the next `CharAtom` from the file.
+    /// Fetches a tuple of the next `CharAtom` from the file and its location,
+    /// which is itself a tuple of (row, column).
     ///
     fn next(&mut self) -> Option<Self::Item> {
-        let raw_codepoint = self.reader.next();
-        let ch = match raw_codepoint {
-            None => return Some(CharAtom::EOF),
-            Some(codepoint) => match codepoint {
-                Codepoint::Invalid(c) => return Some(CharAtom::Invalid(c)),
-                Codepoint::Valid(c) => c,
-            }
-        };
-        return Some(match ch {
-            0x0a => CharAtom::Newline(Newline::LF),
-            0x0d => {
-                if self.reader.lookahead().unwrap_or(0x00) == 0x0a {
-                    self.reader.get_byte();
-                    CharAtom::Newline(Newline::CRLF)
-                } else {
-                    CharAtom::Newline(Newline::CR)
-                }
-            }
-            _ => CharAtom::Valid(std::char::from_u32(ch).unwrap()),
-        })
+	let raw_codepoint = self.reader.next();
+	self.pos.1 += 1;
+	let ch = match raw_codepoint {
+	    None => return Some((CharAtom::EOF, self.pos)),
+	    Some(codepoint) => match codepoint {
+		Codepoint::Invalid(c) => return Some((CharAtom::Invalid(c), self.pos)),
+		Codepoint::Valid(c) => c,
+	    }
+	};
+	let atom = match ch {
+	    0x0a => {
+		CharAtom::Newline(Newline::LF)
+	    }
+	    0x0d => {
+		if self.reader.lookahead().unwrap_or(0x00) == 0x0a {
+		    self.reader.get_byte();
+		    CharAtom::Newline(Newline::CRLF)
+		} else {
+		    CharAtom::Newline(Newline::CR)
+		}
+	    }
+	    _ => CharAtom::Valid(std::char::from_u32(ch).unwrap()),
+	};
+	let out = Some((atom, self.pos));
+	match atom {
+	    CharAtom::Newline(_) => {
+		self.pos = (self.pos.0 + 1, 0);
+	    },
+	    _ => {},
+	};
+	out
     }
 }
 
@@ -279,100 +298,100 @@ mod tests {
 
     /// Utility for making a temporary file.
     fn temp_file(p: &'static str, contents: &[u8]) -> &'static Path {
-        let path = Path::new(p);
-        let mut f = File::create(&path).unwrap();         
-        f.write_all(contents).unwrap();
-        path
+	let path = Path::new(p);
+	let mut f = File::create(&path).unwrap();
+	f.write_all(contents).unwrap();
+	path
     }
 
     #[test]
     fn single_letter() {
-        let path = temp_file("/tmp/ncc-single-letter", b"a");
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Valid('a'),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-single-letter", b"a");
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Valid('a'), (1,1)),
+	    (CharAtom::EOF, (1,2)),
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
     }
 
     #[test]
     fn multi_letter() {
-        let path = temp_file("/tmp/ncc-multi-letter", b"ab");
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Valid('a'),
-            CharAtom::Valid('b'),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-multi-letter", b"ab");
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Valid('a'), (1,1)),
+	    (CharAtom::Valid('b'), (1,2)),
+	    (CharAtom::EOF, (1,3))
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
     }
 
     #[test]
     fn multi_letter_and_newline() {
-        let path = temp_file("/tmp/ncc-multi-letter-and-newline", b"abc\na");
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Valid('a'),
-            CharAtom::Valid('b'),
-            CharAtom::Valid('c'),
-            CharAtom::Newline(Newline::LF),
-            CharAtom::Valid('a'),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-multi-letter-and-newline", b"abc\na");
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Valid('a'), (1,1)),
+	    (CharAtom::Valid('b'), (1,2)),
+	    (CharAtom::Valid('c'), (1,3)),
+	    (CharAtom::Newline(Newline::LF), (1,4)),
+	    (CharAtom::Valid('a'), (2,1)),
+	    (CharAtom::EOF, (2,2)),
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
     }
 
     #[test]
     fn carriage_return() {
-        let path = temp_file("/tmp/ncc-carriage_return", b"a\rc");
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Valid('a'),
-            CharAtom::Newline(Newline::CR),
-            CharAtom::Valid('c'),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-carriage_return", b"a\rc");
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Valid('a'), (1,1)),
+	    (CharAtom::Newline(Newline::CR), (1,2)),
+	    (CharAtom::Valid('c'), (2,1)),
+	    (CharAtom::EOF, (2,2))
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
     }
 
     #[test]
     fn windows_return() {
-        let path = temp_file("/tmp/ncc-windows-return", b"a\r\nc");
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Valid('a'),
-            CharAtom::Newline(Newline::CRLF),
-            CharAtom::Valid('c'),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-windows-return", b"a\r\nc");
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Valid('a'), (1,1)),
+	    (CharAtom::Newline(Newline::CRLF), (1,2)),
+	    (CharAtom::Valid('c'), (2,1)),
+	    (CharAtom::EOF, (2,2))
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
     }
 
     #[test]
     fn broken_codepoints() {
-        let path = temp_file("/tmp/ncc-broken-codepoint", &[0xF0]);
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Invalid(0xF0_00_00_00),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-broken-codepoint", &[0xF0]);
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Invalid(0xF0_00_00_00), (1,1)),
+	    (CharAtom::EOF, (1,2))
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
 
-        let path = temp_file("/tmp/ncc-broken-codepoint-2b", &[0xF0, 0xAA]);
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Invalid(0xF0_AA_00_00),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-broken-codepoint-2b", &[0xF0, 0xAA]);
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Invalid(0xF0_AA_00_00), (1,1)),
+	    (CharAtom::EOF, (1,2))
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
 
-        let path = temp_file("/tmp/ncc-broken-codepoint-3b", &[0xF0, 0xAA, 0xAA]);
-        let reader = AtomReader::new(&path).unwrap();
-        let expected = vec![
-            CharAtom::Invalid(0xF0_AA_AA_00),
-            CharAtom::EOF,
-        ];
-        assert_eq!(reader.take(expected.len()).collect::<Vec<CharAtom>>(), expected);
+	let path = temp_file("/tmp/ncc-broken-codepoint-3b", &[0xF0, 0xAA, 0xAA]);
+	let reader = AtomReader::new(&path).unwrap();
+	let expected = vec![
+	    (CharAtom::Invalid(0xF0_AA_AA_00), (1,1)),
+	    (CharAtom::EOF, (1,2))
+	];
+	assert_eq!(reader.take(expected.len()).collect::<Vec<(CharAtom, FileLoc)>>(), expected);
     }
 }

--- a/src/utils/reader.rs
+++ b/src/utils/reader.rs
@@ -36,7 +36,7 @@ pub struct FileLoc {
 }
 
 impl FileLoc {
-    /// Initializes a `FileLoc` from a tuple (row, column) and a true byte offset.
+    /// Initializes a [FileLoc] from a tuple (row, column) and a true byte offset.
     pub fn new(index: (usize, usize), offset: usize) -> Self {
         FileLoc {
             row: index.0,
@@ -89,13 +89,13 @@ struct CodepointReader {
 }
 
 impl CodepointReader {
-    /// Initializes a `CodepointReader` to read from a file.
+    /// Initializes a [CodepointReader] to read from a file.
     ///
     /// # Arguments
     /// - `path`: The path to the file to be read from.
     ///
     /// # Returns
-    /// Either a `CodepointReader` or a `std::io::Error`
+    /// Either a [CodepointReader] or a [std::io::Error]
     /// if opening file and initial reads fail.
     fn new(path: &Path) -> Result<Self, std::io::Error> {
         let mut reader = CodepointReader {
@@ -232,7 +232,7 @@ impl StreamReader for CodepointReader {
     }
 }
 
-/// Reader for accessing a file a `CharAtom` at a time.
+/// Reader for accessing a file a [CharAtom] at a time.
 ///
 /// # Examples
 /// ```
@@ -251,13 +251,13 @@ pub struct AtomReader {
 }
 
 impl AtomReader {
-    /// Initializes a `AtomReader` to read from a file.
+    /// Initializes a [AtomReader] to read from a file.
     ///
     /// # Arguments
     /// - `path`: The path to the file to be read from.
     ///
     /// # Returns
-    /// Either a `AtomReader` or a `std::io::Error`
+    /// Either a [AtomReader] or a [std::io::Error]
     /// if opening file and initial reads fail.
     pub fn new(path: &Path) -> Result<Self, std::io::Error> {
         Ok(AtomReader {
@@ -270,7 +270,7 @@ impl AtomReader {
 impl StreamReader for AtomReader {
     type Item = (CharAtom, FileLoc);
 
-    /// Fetches a tuple of the next `CharAtom` from the file and its location.
+    /// Fetches a tuple of the next [CharAtom] from the file and its [FileLoc].
     fn consume(&mut self) -> Self::Item {
         self.pos.offset = self.reader.total_offset;
         let raw_codepoint = self.reader.consume();

--- a/src/utils/unicode.rs
+++ b/src/utils/unicode.rs
@@ -1,0 +1,58 @@
+use std::fs::{File};
+
+#[derive(Copy, Debug)]
+enum Newline {
+    LF,
+    CRLF,
+    CR,
+}
+
+#[derive(Copy, Debug)]
+enum CharAtom {
+    Valid(char),
+    Invalid(u16),
+    Newline(Newline),
+    EOF,
+}
+
+struct CodepointReader {
+    f: File,
+    buf: [u16; 1] // TODO: Dubious
+}
+
+impl Iterator for CodepointReader {
+    type Item = u16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+	self.f.read();
+	buf[0]
+    }
+}
+
+struct AtomReader {
+    reader: CodepointReader,
+}
+
+impl Iterator for AtomReader {
+    type Item = Atom;
+
+    fn next(&mut self) -> Option<Self::Item> {
+	let raw_codepoint = self.reader.next();
+	// TODO: Handle \r\n
+	// TODO: Unicode validity checks
+	match raw_codepoint {
+	    0x0a => Newline(Newline::LF),
+	    0x0d => Newline(Newline::CR),	    
+	}
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[test]
+//     fn simple_newline() {
+	
+//     }
+// }

--- a/src/utils/unicode.rs
+++ b/src/utils/unicode.rs
@@ -1,31 +1,88 @@
 use std::fs::{File};
+use std::io::Read;
 
-#[derive(Copy, Debug)]
+/// Returns the initial codepoint accumulator for the first byte.
+/// The first byte is special, only want bottom 5 bits for width 2, 4 bits
+/// for width 3, and 3 bits for width 4.
+#[inline]
+const fn utf8_first_byte(byte: u8, width: u32) -> u32 {
+    (byte & (0x7F >> width)) as u32
+}
+
+/// Mask of the value bits of a continuation byte.
+const CONT_MASK: u8 = 0b0011_1111;
+
+/// Returns the value of `ch` updated with continuation byte `byte`.
+#[inline]
+const fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
+    (ch << 6) | (byte & CONT_MASK) as u32
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Codepoint {
+    Valid(u32),
+    Invalid(u32),
+}
+
+#[derive(Clone, Copy, Debug)]
 enum Newline {
     LF,
     CRLF,
     CR,
 }
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 enum CharAtom {
     Valid(char),
-    Invalid(u16),
+    Invalid(u32),
     Newline(Newline),
     EOF,
 }
 
 struct CodepointReader {
     f: File,
-    buf: [u16; 1] // TODO: Dubious
+    buf: [u8; 4] // TODO: Dubious
 }
 
 impl Iterator for CodepointReader {
-    type Item = u16;
+    type Item = Codepoint;
 
+    // Basically lifted from std::core::str.
     fn next(&mut self) -> Option<Self::Item> {
-	self.f.read();
-	buf[0]
+        let sz = self.f.read(&mut self.buf[..1]).unwrap();
+        if sz == 0 { return None; }
+        else if self.buf[0] < 128 {
+            return Some(Codepoint::Valid(self.buf[0] as u32));
+        }
+
+        let init = utf8_first_byte(self.buf[0], 2);
+        let sz = self.f.read(&mut self.buf[1..2]).unwrap();
+        if sz == 0 { return Some(Codepoint::Invalid((self.buf[0] as u32) << 24)); }
+        let mut ch = utf8_acc_cont_byte(init, self.buf[1]);
+
+        if self.buf[0] >= 0xE0 {
+            let sz = self.f.read(&mut self.buf[2..3]).unwrap();
+            if sz == 0 {
+                return Some(Codepoint::Invalid(
+                    ((self.buf[0] as u32) << 24) | ((self.buf[1] as u32) << 16)
+                ))
+            }
+            let y_z = utf8_acc_cont_byte((self.buf[1] & CONT_MASK) as u32, self.buf[2]);
+            ch = init << 12 | y_z;
+
+            if self.buf[0] >= 0xF0 {
+               let sz = self.f.read(&mut self.buf[3..]).unwrap();
+                if sz == 0 {
+                    return Some(Codepoint::Invalid(
+                        ((self.buf[0] as u32) << 24) | ((self.buf[1] as u32) << 16)
+                            | ((self.buf[2] as u32) << 8)
+                    ))
+                }
+                ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, self.buf[3]);
+            }
+        }
+        self.buf = [0; 4];
+        Some(Codepoint::Valid(ch))
     }
 }
 
@@ -34,16 +91,22 @@ struct AtomReader {
 }
 
 impl Iterator for AtomReader {
-    type Item = Atom;
+    type Item = CharAtom;
 
     fn next(&mut self) -> Option<Self::Item> {
-	let raw_codepoint = self.reader.next();
-	// TODO: Handle \r\n
-	// TODO: Unicode validity checks
-	match raw_codepoint {
-	    0x0a => Newline(Newline::LF),
-	    0x0d => Newline(Newline::CR),	    
-	}
+        let raw_codepoint = self.reader.next();
+        // TODO: Handle \r\n
+        // TODO: Unicode validity checks
+        match raw_codepoint.unwrap() {
+            Codepoint::Valid(c) => {
+                match c {
+                    0x0a => Some(CharAtom::Newline(Newline::LF)),
+                    0x0d => Some(CharAtom::Newline(Newline::CR)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
     }
 }
 
@@ -53,6 +116,6 @@ impl Iterator for AtomReader {
 
 //     #[test]
 //     fn simple_newline() {
-	
+
 //     }
 // }

--- a/src/utils/unicode.rs
+++ b/src/utils/unicode.rs
@@ -1,4 +1,5 @@
-use std::fs::{File};
+use std::fs::File;
+use std::path::Path;
 use std::io::Read;
 
 /// Returns the initial codepoint accumulator for the first byte.
@@ -41,47 +42,113 @@ enum CharAtom {
 
 struct CodepointReader {
     f: File,
-    buf: [u8; 4] // TODO: Dubious
+    buf1: [u8; 4096],
+    buf2: [u8; 4096],
+    index: usize,
+    partial: Option<usize>,
+    secondary: bool,
+    last: bool
+}
+
+impl CodepointReader {
+    fn new(path: &Path) -> Self {
+        let mut reader = CodepointReader {
+            f: File::open(path).unwrap(),
+            buf1: [0; 4096],
+            buf2: [0; 4096],
+            index: 0,
+            partial: None,
+            secondary: false,
+            last: false,
+        };
+        reader.f.read(&mut reader.buf1).unwrap();
+        reader.f.read(&mut reader.buf2).unwrap();
+        reader
+    }
+
+    fn get_byte(&mut self) -> Option<u8> {
+        if self.index == 4096 {
+            if let Some(_) = self.partial {
+                self.last = true;
+            } else {
+                let sz = match self.secondary {
+                    false => self.f.read(&mut self.buf1).unwrap(),
+                    true => self.f.read(&mut self.buf2).unwrap(),
+                };
+                if sz != 4096 { self.partial = Some(sz) }
+            }
+            self.secondary = !self.secondary;
+            self.index = 0;
+        }
+
+        if self.last && self.index > self.partial.unwrap_or(4096) {
+            None
+        } else if self.secondary {
+            Some(self.buf2[self.index])
+        } else {
+            Some(self.buf1[self.index])
+        }
+    }
+
+    // TODO expand capabilities to support rest of multi code point sequences
+    fn lookahead(&self) -> Option<u8> {
+        if self.index == 4096 {
+            match self.secondary {
+                true => Some(self.buf1[0]),
+                false => Some(self.buf2[0]),
+            }
+        } else {
+            if self.index > self.partial.unwrap_or(4096) && self.last {
+                return None;
+            }
+            match self.secondary {
+                false => Some(self.buf1[self.index+1]),
+                true => Some(self.buf2[self.index+1]),
+            }
+        }
+    }
 }
 
 impl Iterator for CodepointReader {
     type Item = Codepoint;
 
-    // Basically lifted from std::core::str.
     fn next(&mut self) -> Option<Self::Item> {
-        let sz = self.f.read(&mut self.buf[..1]).unwrap();
-        if sz == 0 { return None; }
-        else if self.buf[0] < 128 {
-            return Some(Codepoint::Valid(self.buf[0] as u32));
-        }
+        let x = match self.get_byte() {
+            None => return None,
+            Some(c) => c,
+        };
+        if x < 128 { return Some(Codepoint::Valid(x as u32)); }
 
-        let init = utf8_first_byte(self.buf[0], 2);
-        let sz = self.f.read(&mut self.buf[1..2]).unwrap();
-        if sz == 0 { return Some(Codepoint::Invalid((self.buf[0] as u32) << 24)); }
-        let mut ch = utf8_acc_cont_byte(init, self.buf[1]);
-
-        if self.buf[0] >= 0xE0 {
-            let sz = self.f.read(&mut self.buf[2..3]).unwrap();
-            if sz == 0 {
-                return Some(Codepoint::Invalid(
-                    ((self.buf[0] as u32) << 24) | ((self.buf[1] as u32) << 16)
-                ))
-            }
-            let y_z = utf8_acc_cont_byte((self.buf[1] & CONT_MASK) as u32, self.buf[2]);
+        let init = utf8_first_byte(x, 2);
+        let y = match self.get_byte() {
+            None => return Some(Codepoint::Invalid((x as u32) << 24)),
+            Some(c) => c,
+        };
+        let mut ch = utf8_acc_cont_byte(init, y);
+        if x >= 0xE0 {
+            let z = match self.get_byte() {
+                None => {
+                    return Some(Codepoint::Invalid(
+                        ((x as u32) << 24) | ((y as u32) << 16)
+                    ))
+                },
+                Some(c) => c,
+            };
+            let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);
             ch = init << 12 | y_z;
 
-            if self.buf[0] >= 0xF0 {
-               let sz = self.f.read(&mut self.buf[3..]).unwrap();
-                if sz == 0 {
-                    return Some(Codepoint::Invalid(
-                        ((self.buf[0] as u32) << 24) | ((self.buf[1] as u32) << 16)
-                            | ((self.buf[2] as u32) << 8)
-                    ))
-                }
-                ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, self.buf[3]);
+            if x >= 0xF0 {
+                let w = match self.get_byte() {
+                    None => {
+                        return Some(Codepoint::Invalid(
+                            ((x as u32) << 24) | ((y as u32) << 16) | ((z as u32) << 8)
+                        ))
+                    },
+                    Some(c) => c,
+                };                
+                ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
             }
-        }
-        self.buf = [0; 4];
+        }        
         Some(Codepoint::Valid(ch))
     }
 }
@@ -90,23 +157,37 @@ struct AtomReader {
     reader: CodepointReader,
 }
 
+impl AtomReader {
+    fn new(path: &Path) -> Self {
+        AtomReader {
+            reader: CodepointReader::new(path)
+        }
+    }
+}
+
 impl Iterator for AtomReader {
     type Item = CharAtom;
 
     fn next(&mut self) -> Option<Self::Item> {
         let raw_codepoint = self.reader.next();
-        // TODO: Handle \r\n
-        // TODO: Unicode validity checks
-        match raw_codepoint.unwrap() {
-            Codepoint::Valid(c) => {
-                match c {
-                    0x0a => Some(CharAtom::Newline(Newline::LF)),
-                    0x0d => Some(CharAtom::Newline(Newline::CR)),
-                    _ => None,
+        let ch = match raw_codepoint {
+            None => return Some(CharAtom::EOF),
+            Some(codepoint) => match codepoint {
+                Codepoint::Invalid(c) => return Some(CharAtom::Invalid(c)),
+                Codepoint::Valid(c) => c,
+            }
+        };
+        return Some(match ch {            
+            0x0a => CharAtom::Newline(Newline::LF),
+            0x0d => {
+                if self.reader.lookahead().unwrap_or(0x00) == 0x0a {
+                    CharAtom::Newline(Newline::CRLF)
+                } else {
+                    CharAtom::Newline(Newline::CR)
                 }
             }
-            _ => None,
-        }
+            _ => CharAtom::Valid(std::char::from_u32(ch).unwrap()),
+        })
     }
 }
 


### PR DESCRIPTION
# What? 

Core file reading utilities (mostly for the lexer).

Interfaces relevant to the lexer are the `AtomReader`, `CharAtom`, and `FileLoc`.

`AtomReader` handles input buffering Unicode shenanigans and feeds the file to the user as a stream of `CharAtom`s as well as their associated file locations. Each atom is either a valid character, invalid unicode codepoint, newline, or EOF. File locations are in the form of a `FileLoc` struct which contains a one-indexed (row, column) tuples for reporting to stdout and a byte offset in the file.

# Comments

@Radbuglet - any last nitpicks? 
@dwLG00 - try to look over the code quickly and get an idea of what it does, as this is the interface you'll be using.